### PR TITLE
Remove distinction between exact and wildcard subjects

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,15 +1,7 @@
 locals {
-  tfc_workload_identity_workspaces_exact = flatten([
+  tfc_workload_identity_workspaces = flatten([
     for org, workspaces in var.tfc_workload_identity_workspaces : [
-      for workspace in workspaces : [
-        "organization:${org}:workspace:${workspace}:run_phase:plan",
-        "organization:${org}:workspace:${workspace}:run_phase:apply",
-      ] if !can(regex("\\*+", workspace))
-    ]
-  ])
-  tfc_workload_identity_workspaces_wildcard = flatten([
-    for org, workspaces in var.tfc_workload_identity_workspaces : [
-      for workspace in workspaces : "organization:${org}:workspace:${workspace}:run_phase:*" if can(regex("\\*+", workspace))
+      for workspace in workspaces : "organization:${org}:workspace:${workspace}:run_phase:*"
     ]
   ])
 

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ module "tfc_workload_identity_role" {
   # Role must not be created if no workspaces are listed. Otherwise, anyone on TFC with the right
   # audience can assume this role.
   create_role = var.create_tfc_workload_identity_role && (
-    length(local.tfc_workload_identity_workspaces_exact) + length(local.tfc_workload_identity_workspaces_wildcard) > 0
+    length(local.tfc_workload_identity_workspaces) > 0
   )
 
   role_name        = var.tfc_workload_identity_role
@@ -29,8 +29,7 @@ module "tfc_workload_identity_role" {
 
   provider_url = var.create_tfc_oidc_provider ? aws_iam_openid_connect_provider.tfc_provider[0].url : local.oidc_provider_url
 
-  oidc_fully_qualified_subjects  = local.tfc_workload_identity_workspaces_exact
-  oidc_subjects_with_wildcards   = local.tfc_workload_identity_workspaces_wildcard
+  oidc_subjects_with_wildcards   = local.tfc_workload_identity_workspaces
   oidc_fully_qualified_audiences = try(coalescelist(var.tfc_workload_identity_role_audiences, aws_iam_openid_connect_provider.tfc_provider[0].client_id_list), [])
 
   tags = var.tags

--- a/output.tf
+++ b/output.tf
@@ -10,8 +10,5 @@ output "tfc_workload_identity_audience" {
 
 output "tfc_workload_identity_workspaces" {
   description = "Workspaces allowed to assume the Workload Identity IAM Role"
-  value = concat(
-    local.tfc_workload_identity_workspaces_exact,
-    local.tfc_workload_identity_workspaces_wildcard,
-  )
+  value       = local.tfc_workload_identity_workspaces
 }


### PR DESCRIPTION
- Creating a `StringLike` and a `StringEquals` condition simultaneously
turns this into an impossible task to fulfil.

Because both are `AND`ed together.

See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_multi-value-conditions.html

e.g.

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "",
            "Effect": "Allow",
            "Principal": {
                "Federated": "arn:aws:iam::12345678901:oidc-provider/app.terraform.io"
            },
            "Action": "sts:AssumeRoleWithWebIdentity",
            "Condition": {
                "StringEquals": {
                    "app.terraform.io:sub": [
                        "organization:myorg:workspace:workspace:run_phase:apply",
                        "organization:myorg:workspace:workspace:run_phase:plan"
                    ]
                },
                "StringLike": {
                    "app.terraform.io:sub": "organization:sph:workspace:workspace-*:run_phase:*",
                    "app.terraform.io:aud": [
                        "tfc.workload.identity.org",
                        "tfc.workload.identity.myorg"
                    ]
                }
            }
        }
    ]
}
```
